### PR TITLE
fix: fixed pnpm alias support in new lockfile parser version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash.isempty": "^4.4.0",
     "lodash.sortby": "^4.7.0",
     "micromatch": "4.0.7",
-    "snyk-nodejs-lockfile-parser": "1.58.7",
+    "snyk-nodejs-lockfile-parser": "1.58.10",
     "snyk-resolve-deps": "4.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### What this does

nodejs lockfile parser bump