### PR TITLE
chore: fix cross-spawn vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,13 @@
     "lodash.isempty": "^4.4.0",
     "lodash.sortby": "^4.7.0",
     "micromatch": "4.0.8",
-    "snyk-nodejs-lockfile-parser": "1.58.13",
+    "snyk-nodejs-lockfile-parser": "1.58.14",
     "snyk-resolve-deps": "4.8.0"
+  },
+  "overrides": {
+    "@yarnpkg/core": {
+      "cross-spawn": "^7.0.5"
+    }
   },
   "devDependencies": {
     "@types/jest": "^29.5.3",


### PR DESCRIPTION
Fix vuln in `cross-spawn` ([CVE-2024-21538](https://www.cve.org/CVERecord?id=CVE-2024-21538)) via `overrides`