### PR TITLE
fix: [OSM-2329] handle peer-deps-in-dep-path

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash.isempty": "^4.4.0",
     "lodash.sortby": "^4.7.0",
     "micromatch": "4.0.8",
-    "snyk-nodejs-lockfile-parser": "1.58.14",
+    "snyk-nodejs-lockfile-parser": "1.58.16",
     "snyk-resolve-deps": "4.8.0"
   },
   "overrides": {


### PR DESCRIPTION
### What this does

Bumps nodejs-lockfile-parser with changes from https://github.com/snyk/nodejs-lockfile-parser/pull/258.
(fix for pnpm to handle peer dependencies in dependency paths from the lockfile).
