### PR TITLE
fix: [OSM-2314] pnpm fix for codelab refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash.isempty": "^4.4.0",
     "lodash.sortby": "^4.7.0",
     "micromatch": "4.0.8",
-    "snyk-nodejs-lockfile-parser": "1.58.16",
+    "snyk-nodejs-lockfile-parser": "1.58.17",
     "snyk-resolve-deps": "4.8.0"
   },
   "overrides": {


### PR DESCRIPTION
### What this does

Includes these changes: https://github.com/snyk/nodejs-lockfile-parser/pull/260


