### PR TITLE
fix: include peer deps always for pnpm and bump lockfile parser

### DIFF
--- a/lib/lock-parser/build-dep-graph.ts
+++ b/lib/lock-parser/build-dep-graph.ts
@@ -57,6 +57,7 @@ export async function buildDepGraph(
         {
           includeDevDeps: options.includeDevDeps,
           includeOptionalDeps: options.includeOptionalDeps || true,
+          includePeerDeps: true,
           pruneWithinTopLevelDeps: true,
           strictOutOfSync: options.strictOutOfSync,
         },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash.isempty": "^4.4.0",
     "lodash.sortby": "^4.7.0",
     "micromatch": "4.0.8",
-    "snyk-nodejs-lockfile-parser": "1.58.18",
+    "snyk-nodejs-lockfile-parser": "1.58.19",
     "snyk-resolve-deps": "4.8.0"
   },
   "overrides": {


### PR DESCRIPTION
https://github.com/snyk/nodejs-lockfile-parser/pull/264