### PR TITLE
chore: bump snyk-nodejs-lockfile-parser to 2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash.isempty": "^4.4.0",
     "lodash.sortby": "^4.7.0",
     "micromatch": "4.0.8",
-    "snyk-nodejs-lockfile-parser": "2.7.1",
+    "snyk-nodejs-lockfile-parser": "2.8.0",
     "snyk-resolve-deps": "4.8.0"
   },
   "overrides": {


### PR DESCRIPTION
Update the snyk-nodejs-lockfile-parser dependency from 2.7.1 to 2.8.0.

