### PR TITLE
chore: bump snyk-nodejs-lockfile-parser to 2.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash.isempty": "^4.4.0",
     "lodash.sortby": "^4.7.0",
     "micromatch": "4.0.8",
-    "snyk-nodejs-lockfile-parser": "2.8.0",
+    "snyk-nodejs-lockfile-parser": "2.8.1",
     "snyk-resolve-deps": "4.8.0"
   },
   "overrides": {


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy

### What this does

Bumps the pinned `snyk-nodejs-lockfile-parser` dependency from `2.8.0` to `2.8.1` (current `latest`).

2.8.1 changes:
- yarn-berry: prune workspace `devDependencies` from prod graph
- yarn-berry: key workspace prune by resolved name for npm aliases

No code changes are required in this plugin: the only API surface consumed is the stable `PkgTree` type and the namespace import (`import * as lockFileParser`), and 2.8.1 is a bug-fix release with no documented API changes. All existing unit tests pass.

### Notes for the reviewer

Motivation is downstream — [snyk/cli#6888](https://github.com/snyk/cli/pull/6888) needs the yarn-berry `workspacePackages` API (introduced in 2.8.1) to prune dev-only deps of workspace packages consumed as production deps. Without this bump the CLI ends up with two parser versions resident — one transitively via `snyk-nodejs-plugin` at 2.8.0, one directly at 2.8.1 — which the CLI PR reviewer rightly flagged. Bumping here lets the CLI bump `snyk-nodejs-plugin` instead of pinning the parser directly.

To verify locally:

\`\`\`
npm install
npm test
npm run lint
\`\`\`

### More information

- Downstream: https://github.com/snyk/cli/pull/6888
- Parser 2.8.1 release: https://github.com/snyk/nodejs-lockfile-parser/releases/tag/v2.8.1