### PR TITLE
fix: align package.json and release pipeline with npm standard

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
   release:
     <<: *defaults
     docker:
-      - image: node:24
+      - image: cimg/node:24.15.0
     steps:
       - checkout
       - install_deps
@@ -123,7 +123,9 @@ jobs:
           command: npm run build
       - run:
           name: Publish to GitHub
-          command: npx semantic-release@21
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            npx semantic-release@25.0.3
 
 workflows:
   version: 2
@@ -168,7 +170,7 @@ workflows:
           <<: *filters_branches_ignore_main
       - release:
           name: Release
-          context: nodejs-lib-release
+          context: github-release
           requires:
             - Scan repository for secrets
             - Perform security scans for PRs

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "https://github.com/snyk/snyk-nodejs-plugin.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "snyk",
     "nodejs"
@@ -26,7 +29,6 @@
     "node": "^20.18.1 || ^22.13.0 || >=24.0.0"
   },
   "files": [
-    "bin",
     "dist"
   ],
   "bugs": {


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy

### What this does

Prerequisite cleanup for the publish-pipeline migration. Brings `package.json` and the CircleCI release job in line with the [PRODSEC npm Packages Security Standard](https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/4784029774/npm+Packages+Security+Standard).

**`package.json`**
- Add `"publishConfig": {"access": "public"}` — explicit per the standard; aligns with Trusted Publishing setup.
- Drop the stale `"bin"` entry from `files` — there's no `bin/` directory in this repo, so the listing was a no-op that misrepresents what's published.

**`.circleci/config.yml`** (release job only)
- Bump `npx semantic-release@21` → `npx semantic-release@25.0.3` (required for Trusted Publishing). Engine requirement `^22.14.0 || >= 24.10.0` is satisfied by the release image.
- Change release-job image from `node:24` → `cimg/node:24.15.0` so it matches the other jobs in this config.
- Obtain an OIDC token (`NPM_ID_TOKEN`) before the publish command, scoped to `npm:registry.npmjs.org` (standard §3.1.1). semantic-release consumes this for Trusted Publishing:

  \`\`\`yaml
  command: |
    export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
    npx semantic-release@25.0.3
  \`\`\`

- Drop the `nodejs-lib-release` context from the release job (standard §3.3.1). The write-access `NPM_TOKEN` it provided is replaced by the OIDC token above. The `nodejs-install` context (read-only) is intentionally retained on the lint/test/build jobs per §3.4.
- Add the Prodsec-owned `github-release` context to the release job. semantic-release creates GitHub tags + releases via `@semantic-release/github`, which needs the GitHub credentials this context provides.

> ⚠️ Side note: the shared `install_deps` command still writes `${NPM_TOKEN}` into `.npmrc`. In the release job that variable is now empty, which is fine for this repo since all dependencies are public; npm just sees an empty auth entry and falls back to anonymous reads. If the release job ever needs to pull a private package we can revisit (e.g. by giving release a separate install command without the npm-token write).

No code/runtime changes.

`@semantic-release/npm` is intentionally not pinned in this repo — the bundled version that ships with `semantic-release@25` is used, per the standard's recommendation.

### Notes for the reviewer

Motivation: the post-`v2.0.0` releases haven't been publishing because the pipeline needs to be migrated. This PR satisfies the standard's prerequisites so the migration can proceed.

To verify locally:

\`\`\`
npm install
npm run build
npm test
npm run lint
\`\`\`

### More information

- Standard: https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/4784029774/npm+Packages+Security+Standard