### PR TITLE
fix(ci): add nodejs-install context to release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,9 @@ workflows:
           <<: *filters_branches_ignore_main
       - release:
           name: Release
-          context: github-release
+          context:
+            - nodejs-install
+            - github-release
           requires:
             - Scan repository for secrets
             - Perform security scans for PRs


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy

### What this does

Follow-up to #50. The release job's install step uses the shared `install_deps` command, which writes `${NPM_TOKEN}` into `.npmrc`. After #50 dropped the write-access `nodejs-lib-release` context, the release job had only `github-release`, so `NPM_TOKEN` was empty during install (fine for public deps but not aligned with the standard).

Switch the release job to the dual-context layout from the reference setup in the [npm Packages Security Standard](https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/4784029774/npm+Packages+Security+Standard):

\`\`\`yaml
- release:
    name: Release
    context:
      - nodejs-install   # read-only NPM_TOKEN for the install step
      - github-release   # GitHub credentials for semantic-release tags/releases
\`\`\`

Publishing still happens via the OIDC `NPM_ID_TOKEN` obtained in the Publish step; no write-access NPM token is reintroduced.

### Notes for the reviewer

Single-line change. No code/runtime impact. Final piece of the publish-pipeline migration prep.

### More information

- Follow-up to #50
- Standard: https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/4784029774/npm+Packages+Security+Standard