### PR TITLE
feat: [CMPA-603] includeComponentMetadata for npm

### DIFF
--- a/lib/lock-parser/build-dep-graph.ts
+++ b/lib/lock-parser/build-dep-graph.ts
@@ -7,6 +7,9 @@ import {
   ProjectParseOptions,
 } from 'snyk-nodejs-lockfile-parser';
 import { DepGraph } from '@snyk/dep-graph';
+import * as baseDebug from 'debug';
+
+const debug = baseDebug('snyk-nodejs-plugin');
 
 export async function buildDepGraph(
   root: string,
@@ -38,6 +41,19 @@ export async function buildDepGraph(
     workspaceRootPath,
     'pnpm-workspace.yaml',
   );
+
+  if (
+    options.includeComponentMetadata &&
+    lockfileVersion !== NodeLockfileVersion.NpmLockV2 &&
+    lockfileVersion !== NodeLockfileVersion.NpmLockV3
+  ) {
+    debug(
+      `includeComponentMetadata is set but component-metadata labels ` +
+        `(package hashes / distribution URLs) are not yet produced for ` +
+        `lockfile version ${lockfileVersion}; ` +
+        `only npm package-lock v2/v3 is supported`,
+    );
+  }
 
   switch (lockfileVersion) {
     case NodeLockfileVersion.PnpmLockV5:

--- a/lib/lock-parser/index.ts
+++ b/lib/lock-parser/index.ts
@@ -60,7 +60,7 @@ export async function parse(
         includeOptionalDeps: true,
         strictOutOfSync,
         pruneCycles: true,
-        includeComponentMetadata: options.includeComponentMetadata,
+        includeComponentMetadata: options.includeComponentMetadata || false,
       },
     );
   }
@@ -73,6 +73,6 @@ export async function parse(
     strictOutOfSync,
     undefined, // honorAliases
     undefined, // showNpmScope
-    options.includeComponentMetadata,
+    options.includeComponentMetadata || false,
   );
 }

--- a/lib/lock-parser/index.ts
+++ b/lib/lock-parser/index.ts
@@ -71,5 +71,8 @@ export async function parse(
     lockFileFullPath,
     options.dev,
     strictOutOfSync,
+    undefined, // honorAliases
+    undefined, // showNpmScope
+    options.includeComponentMetadata,
   );
 }

--- a/lib/lock-parser/index.ts
+++ b/lib/lock-parser/index.ts
@@ -60,6 +60,7 @@ export async function parse(
         includeOptionalDeps: true,
         strictOutOfSync,
         pruneCycles: true,
+        includeComponentMetadata: options.includeComponentMetadata,
       },
     );
   }

--- a/lib/npm-modules-parser.ts
+++ b/lib/npm-modules-parser.ts
@@ -14,6 +14,13 @@ export function parse(
   targetFile: string,
   options: Options,
 ): Promise<PkgTree> {
+  if (options.includeComponentMetadata) {
+    debug(
+      'includeComponentMetadata is set but resolving via node_modules (no lockfile); ' +
+        'package hash / distribution URL labels are only reported from lockfiles, skipping',
+    );
+  }
+
   if (targetFile.endsWith('yarn.lock')) {
     options.file =
       options.file && options.file.replace('yarn.lock', 'package.json');

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -17,6 +17,7 @@ export interface Options {
   composerPharIsFine?: boolean;
   systemVersions?: object;
   scanAllUnmanaged?: boolean;
+  includeComponentMetadata?: boolean;
 }
 
 export interface ScannedProjectCustom

--- a/lib/workspaces/npm-workspaces-parser.ts
+++ b/lib/workspaces/npm-workspaces-parser.ts
@@ -66,6 +66,7 @@ export async function processNpmWorkspaces(
     dev?: boolean;
     yarnWorkspaces?: boolean;
     showNpmScope?: boolean;
+    includeComponentMetadata?: boolean;
   },
   targetFiles: string[],
 ): Promise<MultiProjectResultCustom> {
@@ -148,6 +149,7 @@ export async function processNpmWorkspaces(
           includeOptionalDeps: false,
           pruneCycles: true,
           showNpmScope: settings.showNpmScope,
+          includeComponentMetadata: settings.includeComponentMetadata,
         },
       );
 

--- a/lib/workspaces/npm-workspaces-parser.ts
+++ b/lib/workspaces/npm-workspaces-parser.ts
@@ -149,7 +149,7 @@ export async function processNpmWorkspaces(
           includeOptionalDeps: false,
           pruneCycles: true,
           showNpmScope: settings.showNpmScope,
-          includeComponentMetadata: settings.includeComponentMetadata,
+          includeComponentMetadata: settings.includeComponentMetadata || false,
         },
       );
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lodash.isempty": "^4.4.0",
     "lodash.sortby": "^4.7.0",
     "micromatch": "4.0.8",
-    "snyk-nodejs-lockfile-parser": "2.8.1",
+    "snyk-nodejs-lockfile-parser": "2.9.0",
     "snyk-resolve-deps": "4.8.0"
   },
   "overrides": {

--- a/test/fixtures/npm/lock-v1/mixed-hashes/package-lock.json
+++ b/test/fixtures/npm/lock-v1/mixed-hashes/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "mixed-hashes",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA=="
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    }
+  }
+}

--- a/test/fixtures/npm/lock-v1/mixed-hashes/package.json
+++ b/test/fixtures/npm/lock-v1/mixed-hashes/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mixed-hashes",
+  "version": "1.0.0",
+  "dependencies": {
+    "accepts": "1.3.7",
+    "ansi-regex": "2.1.1"
+  }
+}

--- a/test/inspect.spec.ts
+++ b/test/inspect.spec.ts
@@ -66,6 +66,38 @@ describe('inspect', () => {
       },
     );
 
+    it('GIVEN includeComponentMetadata for an npm project THEN dep-graph nodes carry hash and distribution:url labels', async () => {
+      const fixturePath = path.resolve(
+        __dirname,
+        'fixtures',
+        'npm',
+        'lock-v2',
+        'simple-app',
+      );
+      process.chdir(fixturePath);
+
+      const withMetadata = await inspect('.', 'package-lock.json', {
+        includeComponentMetadata: true,
+      });
+      const metaNodes = withMetadata.scannedProjects[0].depGraph
+        ?.toJSON()
+        .graph.nodes.filter((node) => node.nodeId !== 'root-node');
+      expect(metaNodes && metaNodes.length).toBeGreaterThan(0);
+      metaNodes?.forEach((node) => {
+        expect(node.info?.labels?.['hash:sha-512']).toMatch(/^[0-9a-f]{128}$/);
+        expect(node.info?.labels?.['distribution:url']).toMatch(/^https:\/\//);
+      });
+
+      // Without the flag the labels must be absent.
+      const withoutMetadata = await inspect('.', 'package-lock.json', {});
+      withoutMetadata.scannedProjects[0].depGraph
+        ?.toJSON()
+        .graph.nodes.forEach((node) => {
+          expect(node.info?.labels?.['hash:sha-512']).toBeUndefined();
+          expect(node.info?.labels?.['distribution:url']).toBeUndefined();
+        });
+    });
+
     it('should throw error trying to scan a pnpm workspace as a simple file', async () => {
       const packageManager = 'pnpm',
         lockFileVersion = '9',

--- a/test/inspect.spec.ts
+++ b/test/inspect.spec.ts
@@ -98,6 +98,44 @@ describe('inspect', () => {
         });
     });
 
+    it('GIVEN includeComponentMetadata for an npm lockfile v1 project THEN depTree nodes carry hash and distribution:url labels', async () => {
+      const fixturePath = path.resolve(
+        __dirname,
+        'fixtures',
+        'npm',
+        'lock-v1',
+        'mixed-hashes',
+      );
+      process.chdir(fixturePath);
+
+      const result = await inspect('.', 'package-lock.json', {
+        includeComponentMetadata: true,
+      });
+      // npm v1 is parsed via the legacy depTree path, not a DepGraph.
+      const depTree = result.scannedProjects[0].depTree as any;
+      expect(depTree).toBeDefined();
+
+      const accepts = depTree.dependencies['accepts'];
+      expect(accepts.labels['hash:sha-512']).toMatch(/^[0-9a-f]{128}$/);
+      expect(accepts.labels['distribution:url']).toBe(
+        'https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz',
+      );
+
+      // sha1 integrity (typical of v1 lockfiles) -> hash:sha-1.
+      const ansiRegex = depTree.dependencies['ansi-regex'];
+      expect(ansiRegex.labels['hash:sha-1']).toMatch(/^[0-9a-f]{40}$/);
+      expect(ansiRegex.labels['distribution:url']).toBe(
+        'https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz',
+      );
+
+      // Without the flag the labels must be absent.
+      const withoutMetadata = await inspect('.', 'package-lock.json', {});
+      const acceptsNoMeta = (withoutMetadata.scannedProjects[0].depTree as any)
+        .dependencies['accepts'];
+      expect(acceptsNoMeta.labels?.['hash:sha-512']).toBeUndefined();
+      expect(acceptsNoMeta.labels?.['distribution:url']).toBeUndefined();
+    });
+
     it('should throw error trying to scan a pnpm workspace as a simple file', async () => {
       const packageManager = 'pnpm',
         lockFileVersion = '9',


### PR DESCRIPTION
- [ ] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [ ] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [ ] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does

Surfaces npm package **hashes** and **distribution URLs** as dep-graph node labels by
threading the `includeComponentMetadata` option through to `snyk-nodejs-lockfile-parser`:

- `hash:<algorithm>` — lowercase-hex digest (`hash:sha-1`, `hash:sha-256`, `hash:sha-512`),
  matching the CycloneDX hash `content` format
- `distribution:url` — the package tarball URL

These feed downstream SBOM generation (CycloneDX component hashes / SPDX package checksums +
download locations). Gated behind the existing FF-driven `--include-component-metadata` flag;
when it's off the dep-graph is unchanged.

### More information

- [CMPA-603](https://snyksec.atlassian.net/browse/CMPA-603)


[CMPA-603]: https://snyksec.atlassian.net/browse/CMPA-603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ