### PR TITLE
feat: thread includeComponentMetadata through yarn paths [CMPA-611]

### DIFF
--- a/lib/lock-parser/build-dep-graph.ts
+++ b/lib/lock-parser/build-dep-graph.ts
@@ -45,13 +45,15 @@ export async function buildDepGraph(
   if (
     options.includeComponentMetadata &&
     lockfileVersion !== NodeLockfileVersion.NpmLockV2 &&
-    lockfileVersion !== NodeLockfileVersion.NpmLockV3
+    lockfileVersion !== NodeLockfileVersion.NpmLockV3 &&
+    lockfileVersion !== NodeLockfileVersion.YarnLockV1
   ) {
     debug(
       `includeComponentMetadata is set but component-metadata labels ` +
         `(package hashes / distribution URLs) are not yet produced for ` +
         `lockfile version ${lockfileVersion}; ` +
-        `only npm package-lock v2/v3 is supported`,
+        `only npm package-lock v2/v3 and yarn.lock v1 are supported ` +
+        `(yarn berry is deferred)`,
     );
   }
 
@@ -89,6 +91,7 @@ export async function buildDepGraph(
           includePeerDeps: options.includePeerDeps || false,
           pruneLevel: 'withinTopLevelDeps',
           strictOutOfSync: options.strictOutOfSync,
+          includeComponentMetadata: options.includeComponentMetadata || false,
         },
       );
     case NodeLockfileVersion.YarnLockV2:
@@ -100,6 +103,8 @@ export async function buildDepGraph(
           includeOptionalDeps: options.includeOptionalDeps,
           pruneWithinTopLevelDeps: true,
           strictOutOfSync: options.strictOutOfSync,
+          // Threaded for a uniform API; berry component-metadata labels are deferred (no-op).
+          includeComponentMetadata: options.includeComponentMetadata || false,
         },
       );
     case NodeLockfileVersion.NpmLockV2:

--- a/lib/workspaces/yarn-workspaces-parser.ts
+++ b/lib/workspaces/yarn-workspaces-parser.ts
@@ -69,6 +69,7 @@ export async function processYarnWorkspaces(
     dev?: boolean;
     yarnWorkspaces?: boolean;
     showNpmScope?: boolean;
+    includeComponentMetadata?: boolean;
   },
   targetFiles: string[],
 ): Promise<MultiProjectResultCustom> {
@@ -166,6 +167,8 @@ export async function processYarnWorkspaces(
                   ? true
                   : settings.strictOutOfSync,
               showNpmScope: settings.showNpmScope,
+              includeComponentMetadata:
+                settings.includeComponentMetadata || false,
             },
           );
           break;
@@ -182,6 +185,9 @@ export async function processYarnWorkspaces(
                   ? true
                   : settings.strictOutOfSync,
               showNpmScope: settings.showNpmScope,
+              // Threaded for a uniform API; berry component-metadata is deferred (no-op).
+              includeComponentMetadata:
+                settings.includeComponentMetadata || false,
             },
             {
               isWorkspacePkg: true,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lodash.isempty": "^4.4.0",
     "lodash.sortby": "^4.7.0",
     "micromatch": "4.0.8",
-    "snyk-nodejs-lockfile-parser": "2.9.0",
+    "snyk-nodejs-lockfile-parser": "2.10.0",
     "snyk-resolve-deps": "4.8.0"
   },
   "overrides": {

--- a/test/inspect.spec.ts
+++ b/test/inspect.spec.ts
@@ -136,6 +136,63 @@ describe('inspect', () => {
       expect(acceptsNoMeta.labels?.['distribution:url']).toBeUndefined();
     });
 
+    it('GIVEN includeComponentMetadata for a yarn v1 project THEN dep-graph nodes carry hash and distribution:url labels', async () => {
+      const fixturePath = path.resolve(
+        __dirname,
+        'fixtures',
+        'yarn',
+        'lock-v1',
+        'simple-app',
+      );
+      process.chdir(fixturePath);
+
+      const withMetadata = await inspect('.', 'yarn.lock', {
+        includeComponentMetadata: true,
+      });
+      const metaNodes = withMetadata.scannedProjects[0].depGraph
+        ?.toJSON()
+        .graph.nodes.filter((node) => node.nodeId !== 'root-node');
+      expect(metaNodes && metaNodes.length).toBeGreaterThan(0);
+      metaNodes?.forEach((node) => {
+        expect(node.info?.labels?.['hash:sha-512']).toMatch(/^[0-9a-f]{128}$/);
+        // fragment stripped -> clean tarball URL (no '#').
+        expect(node.info?.labels?.['distribution:url']).toMatch(
+          /^https:\/\/[^#]+$/,
+        );
+      });
+
+      // Without the flag the labels must be absent.
+      const withoutMetadata = await inspect('.', 'yarn.lock', {});
+      withoutMetadata.scannedProjects[0].depGraph
+        ?.toJSON()
+        .graph.nodes.forEach((node) => {
+          expect(node.info?.labels?.['hash:sha-512']).toBeUndefined();
+          expect(node.info?.labels?.['distribution:url']).toBeUndefined();
+        });
+    });
+
+    it('GIVEN includeComponentMetadata for a yarn berry project THEN labels are deferred (absent)', async () => {
+      const fixturePath = path.resolve(
+        __dirname,
+        'fixtures',
+        'yarn',
+        'lock-v2',
+        'simple-app',
+      );
+      process.chdir(fixturePath);
+
+      const result = await inspect('.', 'yarn.lock', {
+        includeComponentMetadata: true,
+      });
+      result.scannedProjects[0].depGraph
+        ?.toJSON()
+        .graph.nodes.forEach((node) => {
+          expect(node.info?.labels?.['hash:sha-512']).toBeUndefined();
+          expect(node.info?.labels?.['hash:sha-1']).toBeUndefined();
+          expect(node.info?.labels?.['distribution:url']).toBeUndefined();
+        });
+    });
+
     it('should throw error trying to scan a pnpm workspace as a simple file', async () => {
       const packageManager = 'pnpm',
         lockFileVersion = '9',


### PR DESCRIPTION
## What

Extends `includeComponentMetadata` to **yarn** in the node plugin. The option is now accepted on the yarn v1 and yarn v2 (berry) lock-parser paths and the yarn workspaces parser, and forwarded to `snyk-nodejs-lockfile-parser`, so yarn v1 DepGraph nodes gain `hash:*` and `distribution:url` labels.

- `lib/lock-parser/build-dep-graph.ts` — thread the flag into the `parseYarnLockV1Project` / `parseYarnLockV2Project` option objects; update the unsupported-ecosystem debug breadcrumb so yarn v1 is no longer flagged.
- `lib/workspaces/yarn-workspaces-parser.ts` — add the flag to the `processYarnWorkspaces` settings and forward it to both yarn parse calls.
- `package.json` — bump `snyk-nodejs-lockfile-parser` to `2.10.0` (the release that produces the yarn v1 labels).

**yarn berry (v2–4)** is threaded for a uniform API but is a no-op downstream (deferred in the parser — berry lockfiles carry no tarball URL and only a cache checksum, not the published tarball SRI).

## Tests

Adds `inspect` cases: yarn v1 (hash + `distribution:url` labels present with the flag, absent without) and berry (deferred/absent). Full suite green (45 tests).

*Full e2e example*:
```
❯ /Users/calumharrison/.treehouse/cli-fceb68/1/cli/binary-releases/snyk-macos-arm64 sbom --format=cyclonedx1.6+json | jq '.'
{
  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
  "bomFormat": "CycloneDX",
  "specVersion": "1.6",
  "serialNumber": "urn:uuid:6ead07f2-b6b3-4af0-a377-d714dd07b545",
  "version": 1,
  "metadata": {
    "timestamp": "2026-07-09T12:38:56Z",
    "tools": {
      "components": [
        {
          "type": "application",
          "author": "Snyk",
          "name": "snyk-cli",
          "version": "1.1306.0-dev.82bf312b7a0be4dc9a6b3d6107bad86cb9f2b67a"
        }
      ],
      "services": [
        {
          "provider": {
            "name": "Snyk"
          },
          "name": "SBOM Export API",
          "version": "v1.131.0"
        }
      ]
    },
    "component": {
      "bom-ref": "1-trucolor@0.7.1",
      "type": "application",
      "name": "trucolor",
      "version": "0.7.1",
      "purl": "pkg:npm/trucolor@0.7.1",
      "properties": [
        {
          "name": "snyk:npm:scope",
          "value": "unknown"
        }
      ]
    }
  },
  "components": [
    {
      "bom-ref": "2-debug@2.0.0",
      "type": "library",
      "name": "debug",
      "version": "2.0.0",
      "hashes": [
        {
          "alg": "SHA-1",
          "content": "89bd9df6732b51256bc6705342bba02ed12131ef"
        }
      ],
      "licenses": [
        {
          "expression": "MIT"
        }
      ],
      "purl": "pkg:npm/debug@2.0.0",
      "externalReferences": [
        {
          "url": "https://registry.yarnpkg.com/debug/-/debug-2.0.0.tgz",
          "type": "distribution"
        }
      ],
      "properties": [
        {
          "name": "snyk:npm:scope",
          "value": "prod"
        }
      ]
    },
    {
      "bom-ref": "3-ms@0.6.2",
      "type": "library",
      "name": "ms",
      "version": "0.6.2",
      "hashes": [
        {
          "alg": "SHA-1",
          "content": "d89c2124c6fdc1353d65a8b77bf1aac4b193708c"
        }
      ],
      "licenses": [
        {
          "expression": "MIT"
        }
      ],
      "purl": "pkg:npm/ms@0.6.2",
      "externalReferences": [
        {
          "url": "https://registry.yarnpkg.com/ms/-/ms-0.6.2.tgz",
          "type": "distribution"
        }
      ],
      "properties": [
        {
          "name": "snyk:npm:scope",
          "value": "prod"
        }
      ]
    },
    {
      "bom-ref": "4-debug@2.0.0",
      "type": "library",
      "name": "debug",
      "version": "2.0.0",
      "hashes": [
        {
          "alg": "SHA-1",
          "content": "89bd9df6732b51256bc6705342bba02ed12131ef"
        }
      ],
      "licenses": [
        {
          "expression": "MIT"
        }
      ],
      "purl": "pkg:npm/debug@2.0.0",
      "externalReferences": [
        {
          "url": "https://registry.yarnpkg.com/debug/-/debug-2.0.0.tgz",
          "type": "distribution"
        }
      ],
      "properties": [
        {
          "name": "snyk:npm:scope",
          "value": "prod"
        }
      ]
    }
  ],
  "dependencies": [
    {
      "ref": "1-trucolor@0.7.1",
      "dependsOn": [
        "2-debug@2.0.0"
      ]
    },
    {
      "ref": "2-debug@2.0.0",
      "dependsOn": [
        "3-ms@0.6.2"
      ]
    },
    {
      "ref": "3-ms@0.6.2",
      "dependsOn": [
        "4-debug@2.0.0"
      ]
    },
    {
      "ref": "4-debug@2.0.0"
    }
  ]
}
```

## Depends on

`snyk-nodejs-lockfile-parser@2.10.0` (snyk/nodejs-lockfile-parser#314). Second of three PRs: `nodejs-lockfile-parser` → **`snyk-nodejs-plugin`** → `cli`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Option plumbing and dependency bump; behavior change is additive when the flag is set and Berry remains a no-op for metadata.
> 
> **Overview**
> **`includeComponentMetadata`** is now forwarded on **Yarn v1** and **Yarn Berry (v2)** lock parsing (single-project `build-dep-graph` and **yarn workspaces**), alongside the existing npm paths. With the flag enabled, **Yarn v1** DepGraph nodes can get **`hash:*`** and **`distribution:url`** labels via **`snyk-nodejs-lockfile-parser@2.10.0`**; Berry accepts the same option for a uniform API but **does not emit** those labels yet (documented as deferred / no-op downstream).
> 
> The unsupported-ecosystem **debug** message now treats **yarn.lock v1** as supported and only warns for other lockfile types (e.g. pnpm, Berry). **Inspect** tests cover Yarn v1 (labels on/off) and Berry (labels absent with the flag on).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c00156a9294a0d197f8710f345b0ad2c9dc67e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->