### PR TITLE
chore: bump snyk-nodejs-lockfile-parser to 2.10.4

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/open-source_composition-analysis
+* @snyk/engines_sca-scanners

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lodash.isempty": "^4.4.0",
     "lodash.sortby": "^4.7.0",
     "micromatch": "4.0.8",
-    "snyk-nodejs-lockfile-parser": "2.10.0",
+    "snyk-nodejs-lockfile-parser": "2.10.4",
     "snyk-resolve-deps": "4.8.0"
   },
   "overrides": {


### PR DESCRIPTION
Picks up [nodejs-lockfile-parser#325](https://github.com/snyk/nodejs-lockfile-parser/pull/325) (released in [v2.10.4](https://github.com/snyk/nodejs-lockfile-parser/releases/tag/v2.10.4)): pnpm 11+ writes multi-document pnpm-lock.yaml when projects use `configDependencies` or `devEngines.packageManager` (the `pnpm init` default in v11), which previously failed with `YAMLException: expected a single document in the stream, but found more`.

Tracked internally as OSM-3861.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level parser dependency with no local code changes; CODEOWNERS is metadata only.
> 
> **Overview**
> Bumps **`snyk-nodejs-lockfile-parser`** from **2.10.0** to **2.10.4** so lockfile parsing can handle **pnpm 11+** `pnpm-lock.yaml` files that are **multi-document** YAML (e.g. when projects use `configDependencies` or `devEngines.packageManager`). That format previously caused **`YAMLException: expected a single document in the stream, but found more`** during scans.
> 
> Also updates **`.github/CODEOWNERS`** so the default owner is **`@snyk/engines_sca-scanners`** instead of **`@snyk/open-source_composition-analysis`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2153d4b2b351891894535a78e43e8049c4ad06ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->