### PR TITLE
chore: add prodsec-orb-runtime context to config.yaml [PRODSEC-10569]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,7 @@ workflows:
           name: Scan repository for secrets
           context:
             - snyk-bot-slack
+            - prodsec-orb-runtime
           channel: snyk-vuln-alerts-sca
           filters:
             branches:
@@ -144,6 +145,7 @@ workflows:
           name: Perform security scans for PRs
           context:
             - open_source-managed
+            - prodsec-orb-runtime
       - lint:
           name: Lint
           context: nodejs-install


### PR DESCRIPTION
## Summary
This PR adds the `prodsec-orb-runtime` context to jobs and workflows that use prodsec-orb commands.

## Changes
- Added `prodsec-orb-runtime` context to jobs using:
  - `prodsec/secrets-scan`
  - `prodsec/security_scans`
  - `prodsec/container_scan`
  - `publish/publish`

## Related
PRODSEC-10569

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only context wiring for existing prodsec jobs; no application code, auth, or data-path changes.
> 
> **Overview**
> Adds the CircleCI context **`prodsec-orb-runtime`** to two workflow jobs that invoke **`prodsec`** orb steps: **Scan repository for secrets** (`prodsec/secrets-scan`) and **Perform security scans for PRs** (`security-scans` with `prodsec/security_scans`). Each job keeps its existing contexts (`snyk-bot-slack` and `open_source-managed`, respectively) and gains the runtime context so prodsec orb commands can resolve required environment/secrets at execution time (PRODSEC-10569).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d55d13439c7852333a1f9d382066d70e8b363c88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->